### PR TITLE
Fix link and style consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-## Taproot is a proposed Bitcoin protocol upgrade that can be deployed as a backwards-compatibe soft fork. By combining the Schnorr signature algorithm with MAST (Merkelized Abstract Syntax Trees) and a new scripting language called Tapscript, Taproot will expand Bitcoin’s smart contract flexibility, while offering more privacy by letting users mask complex smart contracts as a regular bitcoin transaction.
+## Taproot is a proposed Bitcoin protocol upgrade that can be deployed as a forward-compatible soft fork. By combining the Schnorr signature algorithm with MAST (Merklized Abstract Syntax Trees) and a new scripting language called Tapscript, Taproot will expand Bitcoin’s smart contract flexibility, while offering more privacy by letting users mask complex smart contracts as a regular bitcoin transaction.
 More in depth information can be found in this article [Taproot Is Coming: What It Is, And How It Will Benefit Bitcoin](https://bitcoinmagazine.com/articles/taproot-coming-what-it-and-how-it-will-benefit-bitcoin)
  
   ------
  
-A softfork is a change to the bitcoin protocol wherein only previously valid blocks/transactions are made invalid. Since old nodes will recognize the new blocks as valid, a softfork is backward-compatible. See more here: [Soft fork bitcoin wiki]https://en.bitcoin.it/wiki/Softfork
+A soft fork is a change to the Bitcoin protocol wherein only previously valid blocks/transactions are made invalid. Since old nodes will recognize the new blocks as valid, a soft fork is forward-compatible. See more here: [Soft fork bitcoin wiki](https://en.bitcoin.it/wiki/Softfork)
 
-Soft forks can be activated in several ways. Several of the previous soft forks have been activated using BIP 9 (Bitcoin Improvement Proposal 9), which requires a (super)majority of miners (by hash power) to signal support for the upgrade. A proposed alternative is BIP 8, which could activate the upgrade after some time even without a (super)majority of miners signaling support. There are also ideas to combine BIP 9-style activation with BIP 8-style activation.
+Soft forks can be activated in several ways. Several of the previous soft forks have been activated using [BIP 9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) (Bitcoin Improvement Proposal 9), which requires a (super)majority of miners (by hash power) to signal support for the upgrade. A proposed alternative is [BIP 8](https://github.com/bitcoin/bips/blob/master/bip-0008.mediawiki), which could activate the upgrade after some time even without a (super)majority of miners signaling support. There are also ideas to combine BIP 9-style activation with BIP 8-style activation.
 
 In short:
   
-1. **BIP 9 (and BIP 8 without forced activation):** The upgrade will activate if and when 95% of hash power signals support for the upgrade. If after a year this threshold hasn't been reached, the upgrade expires. Both the 95% treshold and the one-year expiry parameters could be set differently.
+1. **BIP 9 (and BIP 8 without forced activation):** The upgrade will activate if and when 95% of hash power signals support for the upgrade. If after a year this threshold hasn't been reached, the upgrade expires. Both the 95% threshold and the one-year expiry parameters could be set differently.
 
-1. **BIP 8 (with forced activation):** The upgrade will activate if and when 95% of hash power signals support for the upgrade. If after a year this threshold hasn't been reached, the upgrade activates regardless, and blocks that don't follow the new rules will be rejected. Both the 95% treshold and the one-year expiry parameters could be set differently.
+1. **BIP 8 (with forced activation):** The upgrade will activate if and when 95% of hash power signals support for the upgrade. If after a year this threshold hasn't been reached, the upgrade activates regardless, and blocks that don't follow the new rules will be rejected. Both the 95% threshold and the one-year expiry parameters could be set differently.
 
 There are also ideas to combine different proposals. For example, try BIP 9 first, if it expires, try again with BIP 8 (with forced activation). More in depth information on Taproot activation can be found in this Bitcoin Magazine article by Aaron van Wirdum: [BIP 8, BIP 9 Or Modern Soft Fork Activation: How Bitcoin Could Upgrade Next](https://bitcoinmagazine.com/articles/bip-8-bip-9-or-modern-soft-fork-activation-how-bitcoin-could-upgrade-next)
 


### PR DESCRIPTION
* Fixed the link to the Bitcoin wiki soft fork page
* Bitcoin protocol was capitalized in the beginning, so I amended it to
be capitalized everywhere
* Soft fork was written as two words sometimes and sometimes as one
word, made it consistently written as two words
* Both hard forks and soft forks are backward-compatible (in each case
the new software can read old blocks), but only soft forks are
forward-compatible (where old software accepts new blocks).
* Added links to BIP8 and BIP9